### PR TITLE
Temporary Trakt Server Problems when browsing trakt_progress_list.

### DIFF
--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -2957,6 +2957,6 @@ msgid "Originals (TVMaze)"
 msgstr ""
 
 msgctxt "#40072"
-msgid ""
+msgid "Getting Episode From cached."
 msgstr ""
 

--- a/resources/lib/menus/episodes.py
+++ b/resources/lib/menus/episodes.py
@@ -253,6 +253,9 @@ class Episodes:
 					self.list = cache.get(self.trakt_progress_list, 24, url, self.trakt_user, self.lang, direct)
 				except:
 					self.list = cache.get(self.trakt_progress_list, 0, url, self.trakt_user, self.lang, direct)
+					if len(self.list) < 0:
+						control.notification(title=32326, message=40072, icon='INFO', sound=notificationSound)
+						self.list = cache.get(self.trakt_progress_list, 720, url, self.trakt_user, self.lang, direct)
 				self.sort(type = 'progress')
 
 			elif self.trakt_link in url and url == self.mycalendar_link:


### PR DESCRIPTION
when there is 'Temporary Trakt Server Problems' it don't show episode list in progress menu ,this change could get you previous cache list.