### PR TITLE
Version check for base32_to_hex in rd_cache_chk_list for Matrix

### DIFF
--- a/resources/lib/modules/sources.py
+++ b/resources/lib/modules/sources.py
@@ -1351,8 +1351,13 @@ class Sources:
 		if len(torrent_List) == 0: return
 		def base32_to_hex(hash):
 			from base64 import b32decode
+			from resources.lib.modules import py_tools
 			log_utils.log('base32 hash: %s' % hash, __name__, log_utils.LOGDEBUG)
-			hex = b32decode(hash).encode('hex') # 19 compatible?
+
+			if py_tools.isPY3:
+				hex = b32decode(hash).hex()
+			else
+				hex = b32decode(hash).encode('hex') 
 			log_utils.log('base32_to_hex: %s' % hex, __name__, log_utils.LOGDEBUG)
 			return hex
 		try:

--- a/resources/lib/modules/sources.py
+++ b/resources/lib/modules/sources.py
@@ -1353,7 +1353,6 @@ class Sources:
 			from base64 import b32decode
 			from resources.lib.modules import py_tools
 			log_utils.log('base32 hash: %s' % hash, __name__, log_utils.LOGDEBUG)
-
 			if py_tools.isPY3:
 				hex = b32decode(hash).hex()
 			else


### PR DESCRIPTION
This fixes the hex encoding under Win10 x64

```
[COLOR red][ Venom: DEBUG ][/COLOR]: From func name: resources.lib.modules.sources.base32_to_hex() Line # :1354
                       msg : base32 hash: SZBM26XCLPFGMRDE7ALGRGJW3433WWIK (ENCODED)
[2021-03-06 21:43:15] [COLOR red][ Venom: ERROR ][/COLOR]: From func name: \resources\lib\modules\sources.py.rd_cache_chk_list() Line # :1359
                       msg : AttributeError -> 'bytes' object has no attribute 'encode' (ENCODED)
```